### PR TITLE
Fiilter Inject by Id (string)

### DIFF
--- a/Assets/Reflex.EditModeTests/ContainerTests.cs
+++ b/Assets/Reflex.EditModeTests/ContainerTests.cs
@@ -43,11 +43,34 @@ namespace Reflex.EditModeTests
         }
 
         [Test]
+        public void Resolve_SingletonById_ShouldReturn42AndAddedToAll()
+        {
+            string id = "AnswerToEverything";
+            var container = new ContainerBuilder()
+                .AddSingleton(24, typeof(int)) //Add something before int with identifier
+                .AddSingleton(42, id)
+                .AddSingleton(12, typeof(int)) //Override "last" to test if the correct value is returned by using id
+                .Build();
+            
+            container.All<int>().Should().HaveCount(3);
+            container.All<int>().Should().ContainInOrder(24, 42, 12);
+            container.Single<int>(id).Should().Be(42);
+        }
+
+        [Test]
         public void Resolve_UninstalledValueType_ShouldThrowUnknownContractException()
         {
             var container = new ContainerBuilder().Build();
             Action resolve = () => container.Single<int>();
             resolve.Should().Throw<UnknownContractException>();
+        }
+
+        [Test]
+        public void Resolve_UninstalledIdentifier_ShouldThrowUnknownIdException()
+        {
+            var container = new ContainerBuilder().Build();
+            Action resolve = () => container.Single<int>("identifier");
+            resolve.Should().Throw<UnknownIdentifierException>();
         }
 
         [Test]
@@ -280,6 +303,21 @@ namespace Reflex.EditModeTests
         {
             var container = new ContainerBuilder().AddSingleton(42).Build();
             container.HasBinding<int>().Should().BeTrue();
+        }
+        
+        [Test]
+        public void HasBindingByIdReturnFalseWhenBindingIsNotDefined()
+        {
+            var container = new ContainerBuilder().Build();
+            container.HasBinding("AnswerToEverything").Should().BeFalse();
+        }
+        
+        [Test]
+        public void HasBindingByIdReturnTrueWhenBindingIsDefined()
+        {
+            string id = "AnswerToEverything";
+            var container = new ContainerBuilder().AddSingleton(42, id).Build();
+            container.HasBinding(id).Should().BeTrue();
         }
     }
 }

--- a/Assets/Reflex/Attributes/InjectAttribute.cs
+++ b/Assets/Reflex/Attributes/InjectAttribute.cs
@@ -7,5 +7,19 @@ namespace Reflex.Attributes
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method)]
     public class InjectAttribute : Attribute
     {
+        public string Identifier { get; } = null;
+        
+        public bool HasIdentifier => !string.IsNullOrEmpty(Identifier);
+
+        public InjectAttribute()
+        {
+            
+        }
+
+        public InjectAttribute([NotNull] string identifier)
+        {
+            Identifier = identifier;
+        }
+        
     }
 }

--- a/Assets/Reflex/Core/Binding.cs
+++ b/Assets/Reflex/Core/Binding.cs
@@ -8,7 +8,8 @@ namespace Reflex.Core
     {
         public IResolver Resolver { get; }
         public Type[] Contracts { get; }
-
+        public string Identifier { get; } = null;
+        
         private Binding()
         {
         }
@@ -17,6 +18,13 @@ namespace Reflex.Core
         {
             Resolver = resolver;
             Contracts = contracts;
+        }
+
+        private Binding(IResolver resolver, Type[] contracts, string identifier)
+        {
+            Resolver = resolver;
+            Contracts = contracts;
+            Identifier = identifier;
         }
 
         public static Binding Validated(IResolver resolver, Type concrete, params Type[] contracts)
@@ -30,6 +38,19 @@ namespace Reflex.Core
             }
 
             return new Binding(resolver, contracts);
+        }
+
+        public static Binding Validated(IResolver resolver, Type concrete, string identifier, params Type[] contracts)
+        {
+            foreach (var contract in contracts)
+            {
+                if (!contract.IsAssignableFrom(concrete))
+                {
+                    throw new ContractDefinitionException(concrete, contract);
+                }
+            }
+
+            return new Binding(resolver, contracts, identifier);
         }
     }
 }

--- a/Assets/Reflex/Exceptions/UnknownIdentifierException.cs
+++ b/Assets/Reflex/Exceptions/UnknownIdentifierException.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Reflex.Exceptions
+{
+    public sealed class UnknownIdentifierException : Exception
+    {
+        public UnknownIdentifierException(string identifier) : base(GenerateMessage(identifier))
+        {
+        }
+
+        private static string GenerateMessage(string identifier)
+        {
+            return $"Cannot resolve id '{identifier}'.";
+        }
+    }
+}

--- a/Assets/Reflex/Exceptions/UnknownIdentifierException.cs.meta
+++ b/Assets/Reflex/Exceptions/UnknownIdentifierException.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d78c2ee220b3437d976fbfa6afcbfa7f
+timeCreated: 1741279184

--- a/Assets/Reflex/Injectors/FieldInjector.cs
+++ b/Assets/Reflex/Injectors/FieldInjector.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using Reflex.Attributes;
 using Reflex.Core;
 using Reflex.Exceptions;
 
@@ -11,7 +12,7 @@ namespace Reflex.Injectors
         {
             try
             {
-                field.SetValue(instance, container.Resolve(field.FieldType));
+                field.SetValue(instance, container.Resolve(field.FieldType, field.GetCustomAttribute<InjectAttribute>()));
             }
             catch (Exception e)
             {

--- a/Assets/Reflex/Injectors/PropertyInjector.cs
+++ b/Assets/Reflex/Injectors/PropertyInjector.cs
@@ -2,6 +2,7 @@ using System;
 using System.Reflection;
 using Reflex.Core;
 using Reflex.Exceptions;
+using Reflex.Attributes;
 
 namespace Reflex.Injectors
 {
@@ -11,7 +12,7 @@ namespace Reflex.Injectors
         {
             try
             {
-                property.SetValue(instance, container.Resolve(property.PropertyType));
+                property.SetValue(instance, container.Resolve(property.PropertyType, property.GetCustomAttribute<InjectAttribute>()));
             }
             catch (Exception e)
             {


### PR DESCRIPTION
# Pull Request Template

## Description

Add the ability to bind objects with an identifier.
This allows to inject a single specific instance by using the Inject attribute with the same identifier.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Implemented ContainerTests:
- [x] HasBindingByIdReturnFalseWhenBindingIsNotDefined
- [x] HasBindingByIdReturnTrueWhenBindingIsDefined
- [x] Resolve_UninstalledIdentifier_ShouldThrowUnknownIdException
- [x] Resolve_SingletonById_ShouldReturn42AndAddedToAll

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
- [ ] I have checked that Reflex.GettingStarted still runs nicely
